### PR TITLE
align the scale of x-axis of the histogram

### DIFF
--- a/src/eda_covid19.r
+++ b/src/eda_covid19.r
@@ -122,8 +122,9 @@ create_distribution_plot <- function(data, code, country) {
   data %>%
     filter(iso_code == code) %>%
     ggplot(aes(response_ratio)) +
-    geom_histogram(bins = 50) +
+    geom_histogram(bins = 80) +
     xlab(paste0("Response Ratio, ", country)) +
+    xlim(0, 200) +
     ggtitle(paste0("Sample Distribution of ", country, "'s Response Ratio")) +
     theme(plot.title = element_text(size = 9)) +
     theme(axis.title = element_text(size = 9))


### PR DESCRIPTION
This PR addresses TA feedback in issue#64: "You can improve figure 1 by aligning the scales of the x-axis to make it easier to compare the two distributions visually."